### PR TITLE
Fix port config for button on STM32G031 Discovery Kit

### DIFF
--- a/system.c
+++ b/system.c
@@ -66,16 +66,14 @@ static void init_gpio(void) {
 		};
 		HAL_GPIO_Init(GPIOA, &gpio_init_struct);
 	}
-
-	__HAL_RCC_GPIOB_CLK_ENABLE();
 	{
 		GPIO_InitTypeDef gpio_init_struct = {
-				.Pin = GPIO_PIN_7,
+				.Pin = GPIO_PIN_1,
 				.Mode = GPIO_MODE_INPUT,
 				.Speed = GPIO_SPEED_FREQ_HIGH,
 				.Pull = GPIO_PULLUP,
 		};
-		HAL_GPIO_Init(GPIOB, &gpio_init_struct);
+		HAL_GPIO_Init(GPIOA, &gpio_init_struct);
 	}
 }
 

--- a/system.c
+++ b/system.c
@@ -75,6 +75,17 @@ static void init_gpio(void) {
 		};
 		HAL_GPIO_Init(GPIOA, &gpio_init_struct);
 	}
+
+	__HAL_RCC_GPIOB_CLK_ENABLE();
+	{
+		GPIO_InitTypeDef gpio_init_struct = {
+				.Pin = GPIO_PIN_7,
+				.Mode = GPIO_MODE_INPUT,
+				.Speed = GPIO_SPEED_FREQ_HIGH,
+				.Pull = GPIO_PULLUP,
+		};
+		HAL_GPIO_Init(GPIOB, &gpio_init_struct);
+	}
 }
 
 void SystemInit(void) {


### PR DESCRIPTION
Fixes the PORT Config (pull-up, etc.) for the input button which seems to be mapped to A1 instead of B7 on STM32G031 Discovery Kit (ST part number: STM32G0316-DISCO).

~Might be a breaking change for users not using this kit.~
